### PR TITLE
Rebase v0.3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 manifests: fixed2clusters fixed3clusters
 
 fixed2clusters:
-# flag --load_restrictor LoadRestrictionsNone is used because kustomize by default
+# flag --load-restrictor LoadRestrictionsNone is used because kustomize by default
 # expects base resources to be in or below the building directory. 
 # In this case base files are in /release and patch files in /overlays
-	kustomize build --load_restrictor LoadRestrictionsNone overlays/fixed-2clusters/ > release/fixed-2clusters.yaml
+	kustomize build --load-restrictor LoadRestrictionsNone overlays/fixed-2clusters/ -o release/fixed-2clusters.yaml
 fixed3clusters:
-	kustomize build --load_restrictor LoadRestrictionsNone overlays/fixed-3clusters/ > release/fixed-3clusters.yaml
+	kustomize build --load-restrictor LoadRestrictionsNone overlays/fixed-3clusters/ -o release/fixed-3clusters.yaml

--- a/release/fixed-2clusters.yaml
+++ b/release/fixed-2clusters.yaml
@@ -554,6 +554,8 @@ spec:
       - env:
         - name: PORT
           value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
         image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         livenessProbe:
           exec:

--- a/release/fixed-2clusters.yaml
+++ b/release/fixed-2clusters.yaml
@@ -186,7 +186,7 @@ spec:
           value: "1"
         - name: DISABLE_TRACING
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -245,7 +245,7 @@ spec:
           value: "7070"
         - name: LISTEN_ADDR
           value: 0.0.0.0
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -319,7 +319,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -375,7 +375,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -431,7 +431,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -498,13 +498,7 @@ spec:
           value: checkoutservice:5050
         - name: AD_SERVICE_ADDR
           value: adservice:9555
-        - name: ENV_PLATFORM
-          value: gcp
-        - name: DISABLE_TRACING
-          value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
-        image: gcr.io/google-samples/microservices-demo/frontend:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
         livenessProbe:
           httpGet:
             httpHeaders:
@@ -560,7 +554,7 @@ spec:
       - env:
         - name: PORT
           value: "50051"
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -611,13 +605,7 @@ spec:
       - env:
         - name: PORT
           value: "3550"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -676,7 +664,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -786,7 +774,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
         livenessProbe:
           exec:
             command:

--- a/release/fixed-3clusters.yaml
+++ b/release/fixed-3clusters.yaml
@@ -562,6 +562,8 @@ spec:
       - env:
         - name: PORT
           value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
         image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         livenessProbe:
           exec:

--- a/release/fixed-3clusters.yaml
+++ b/release/fixed-3clusters.yaml
@@ -187,7 +187,7 @@ spec:
           value: "1"
         - name: DISABLE_TRACING
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -247,7 +247,7 @@ spec:
           value: "7070"
         - name: LISTEN_ADDR
           value: 0.0.0.0
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -322,7 +322,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -368,7 +368,7 @@ spec:
               - key: region
                 operator: In
                 values:
-                - B
+                - A
       containers:
       - env:
         - name: PORT
@@ -379,7 +379,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -427,7 +427,7 @@ spec:
               - key: region
                 operator: In
                 values:
-                - B
+                - A
       containers:
       - env:
         - name: PORT
@@ -436,7 +436,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -505,13 +505,7 @@ spec:
           value: checkoutservice:5050
         - name: AD_SERVICE_ADDR
           value: adservice:9555
-        - name: ENV_PLATFORM
-          value: gcp
-        - name: DISABLE_TRACING
-          value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
-        image: gcr.io/google-samples/microservices-demo/frontend:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
         livenessProbe:
           httpGet:
             httpHeaders:
@@ -568,7 +562,7 @@ spec:
       - env:
         - name: PORT
           value: "50051"
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -615,18 +609,12 @@ spec:
               - key: region
                 operator: In
                 values:
-                - B
+                - A
       containers:
       - env:
         - name: PORT
           value: "3550"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -673,7 +661,7 @@ spec:
               - key: region
                 operator: In
                 values:
-                - B
+                - A
       containers:
       - env:
         - name: PORT
@@ -686,7 +674,7 @@ spec:
           value: "1"
         - name: DISABLE_DEBUGGER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
         livenessProbe:
           exec:
             command:
@@ -735,7 +723,7 @@ spec:
               - key: region
                 operator: In
                 values:
-                - B
+                - A
       containers:
       - image: redis:alpine
         livenessProbe:
@@ -798,7 +786,7 @@ spec:
           value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.0
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
         livenessProbe:
           exec:
             command:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -329,6 +329,8 @@ spec:
         env:
         - name: PORT
           value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]


### PR DESCRIPTION
Google took down `adservice:0.2.0` due to the Log4j vuln (see upstream readme), so I rebased the repo on top of v0.3.4 and regenerated the files.